### PR TITLE
fix(format): reformat yaml structure

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,7 @@
 ---
 - name: restart outlyer-agent
-  service: name=outlyer-agent enabled=yes state=restarted
+  service:
+    name: outlyer-agent
+    enabled: yes
+    state: restarted
   when: outlyer_manage_service

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,12 +1,19 @@
 ---
 # Ubuntu specific dataloop stuff
 - name: install https apt transport
-  apt: name=apt-transport-https state=present
+  apt:
+    name: apt-transport-https
+    state: present
 
 # Add an Apt signing key, will not download if present
 - name: Outlyer gpg key
-  apt_key: id=ACB6D967 url='https://packages.outlyer.com/outlyer-pubkey.gpg' state=present
+  apt_key:
+    id: ACB6D967
+    url: https://packages.outlyer.com/outlyer-pubkey.gpg
+    state: present
 
 - name: Outlyer apt repository
-  apt_repository: repo='deb https://packages.outlyer.com/debian/ stable main' state=present
-  filename: outlyer.list
+  apt_repository:
+    repo: deb https://packages.outlyer.com/debian/ stable main
+    state: present
+    filename: outlyer.list

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,16 @@
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' or ansible_distribution == 'RedHat' or ansible_distribution == 'Amazon'
 
 - name: Install Outlyer Agent
-  package: name=outlyer-agent state=present
+  package:
+    name: outlyer-agent
+    state: present
 
 - name: outlyer config
   become: yes
-  template: src=outlyer-agent.yaml.j2 dest=/etc/outlyer/agent.yaml owner=outlyer group=outlyer mode=640
+  template:
+    src: outlyer-agent.yaml.j2
+    dest: /etc/outlyer/agent.yaml
+    owner: outlyer
+    group: outlyer
+    mode: 640
   notify: restart outlyer-agent

--- a/tasks/rhel.yml
+++ b/tasks/rhel.yml
@@ -2,10 +2,13 @@
 #RHEL specific tasks
 # msg: Aborting, target uses selinux but python bindings (libselinux-python) aren't installed!
 - name: Install libselinux-python
-  yum: name=libselinux-python
+  yum:
+    name: libselinux-python
 
 - name: Import Oulyer package signing gpg key
-  rpm_key: key='https://packages.outlyer.com/outlyer-pubkey.gpg' state=present
+  rpm_key:
+    key: https://packages.outlyer.com/outlyer-pubkey.gpg
+    state: present
 
 - name: Outlyer Yum Repository
   yum_repository:


### PR DESCRIPTION
# Goal and description

Reformatting ansible commands.

I ran into an issue: https://github.com/outlyerapp/outlyer-ansible/pull/3/commits/762b0e9e5e33c6f91a356d94157b54ab41c8162b#diff-d970ffa13a0f7023ed5e2498c37c9cb3R19

`filename` was not a property of `Tasks`, but a property of `apt_repository`.
